### PR TITLE
Fix reordering when child nodes shouldn't be reordered

### DIFF
--- a/frontend/src/dashboard/content/responseConfiguration/conversation/node/PalavyrNode.tsx
+++ b/frontend/src/dashboard/content/responseConfiguration/conversation/node/PalavyrNode.tsx
@@ -180,8 +180,7 @@ export abstract class PalavyrNodeBase implements IPalavyrNode {
     }
 
     public sortChildReferences() {
-        // reorder parent's child refs depending on if parent is a anabranch
-        if (!this.isPalavyrAnabranchStart) {
+        if (!this.isPalavyrAnabranchStart && !this.isLoopbackAnchorType && this.nodeType !== "MultipleChoiceAsPath") {
             this.childNodeReferences.OrderByOptionPath();
         }
     }


### PR DESCRIPTION
e.g. 
 - loopback anchor
 - multioption as path
 - anabranch start