### PR TITLE
Return a resource that allows the dateTime for convo history to be stringified

### DIFF
--- a/server/Palavyr.API/Controllers/Enquiries/GetEnquiryDetailsController.cs
+++ b/server/Palavyr.API/Controllers/Enquiries/GetEnquiryDetailsController.cs
@@ -13,15 +13,13 @@ namespace Palavyr.API.Controllers.Enquiries
         public const string Route = "enquiries/review/{conversationId}";
 
 
-        public GetCompleteConversationDetailsController(
-            IMediator mediator
-        )
+        public GetCompleteConversationDetailsController(IMediator mediator)
         {
             this.mediator = mediator;
         }
 
         [HttpGet(Route)]
-        public async Task<ConversationHistory[]> Get([FromRoute] string conversationId, CancellationToken cancellationToken)
+        public async Task<ConversationRowsResource[]> Get([FromRoute] string conversationId, CancellationToken cancellationToken)
         {
             var response = await mediator.Send(new GetCompleteConversationDetailsRequest(conversationId), cancellationToken);
             return response.Response;

--- a/server/Palavyr.Core/Handlers/GetCompleteConversationDetailsHandler.cs
+++ b/server/Palavyr.Core/Handlers/GetCompleteConversationDetailsHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -27,16 +28,45 @@ namespace Palavyr.Core.Handlers
                 .ConversationHistories
                 .Where(row => row.ConversationId == request.ConversationId)
                 .ToListAsync(cancellationToken);
-
             convoRows.Sort((x, y) => x.Id > y.Id ? 1 : -1);
-            return new GetCompleteConversationDetailsResponse(convoRows.ToArray());
+
+            var resources = new List<ConversationRowsResource>();
+            foreach (var row in convoRows)
+            {
+                var newResource = new ConversationRowsResource
+                {
+                    ConversationId = row.ConversationId,
+                    Prompt = row.Prompt,
+                    UserResponse = row.UserResponse,
+                    NodeId = row.NodeId,
+                    NodeCritical = row.NodeCritical,
+                    NodeType = row.NodeType,
+                    TimeStamp = row.TimeStamp.ToString(),
+                    AccountId = row.AccountId
+                };
+                resources.Add(newResource);
+            }
+
+            return new GetCompleteConversationDetailsResponse(resources.ToArray());
         }
+    }
+
+    public class ConversationRowsResource
+    {
+        public string ConversationId { get; set; }
+        public string Prompt { get; set; }
+        public string UserResponse { get; set; }
+        public string NodeId { get; set; }
+        public bool NodeCritical { get; set; }
+        public string NodeType { get; set; }
+        public string TimeStamp { get; set; }
+        public string AccountId { get; set; }
     }
 
     public class GetCompleteConversationDetailsResponse
     {
-        public GetCompleteConversationDetailsResponse(ConversationHistory[] response) => Response = response;
-        public ConversationHistory[] Response { get; set; }
+        public GetCompleteConversationDetailsResponse(ConversationRowsResource[] response) => Response = response;
+        public ConversationRowsResource[] Response { get; set; }
     }
 
     public class GetCompleteConversationDetailsRequest : IRequest<GetCompleteConversationDetailsResponse>

--- a/ui/src/frontend/dashboard/content/responseConfiguration/response/tables/dynamicTable/DynamicTableConfiguration.tsx
+++ b/ui/src/frontend/dashboard/content/responseConfiguration/response/tables/dynamicTable/DynamicTableConfiguration.tsx
@@ -20,7 +20,6 @@ export interface IDynamicTable {
 export const DynamicTableConfiguration = ({ title, areaIdentifier, children }: IDynamicTable) => {
     const { repository, planTypeMeta, setSuccessOpen } = useContext(DashboardContext);
 
-    const [loaded, setLoaded] = useState<boolean>(false);
     const [showDebug, setShowDebug] = useState<boolean>(false);
     const [availableTables, setAvailableTables] = useState<Array<string>>([]);
     const [tableNameMap, setTableNameMap] = useState<TableNameMap>({});
@@ -46,7 +45,6 @@ export const DynamicTableConfiguration = ({ title, areaIdentifier, children }: I
             counter++;
             if (counter === dynamicTableMetas.length) {
                 setTables(tables);
-                setLoaded(true);
 
                 // enable / disable the selector depending on if the current pricing strategy has been included in the conversation nodes
                 setInUse(isInUse);
@@ -90,13 +88,7 @@ export const DynamicTableConfiguration = ({ title, areaIdentifier, children }: I
     };
 
     useEffect(() => {
-        // if (!loaded) {
         loadTableData();
-        // setLoaded(true);
-        // }
-        // return () => {
-        //     return setLoaded(false);
-        // };
     }, [areaIdentifier, loadTableData]);
 
     const changeShowTotals = async (e: { target: { checked: any } }) => {


### PR DESCRIPTION
Quick fix for a longstanding problem with the datetime not being converted to string before returning from the API.

This is a temp fix in lieu of a proper mappers solution. We still return models from the api, which we shouldn't be doing.